### PR TITLE
Remove "folder" from section titles, add in text

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,19 +6,21 @@ As the project continues to develop over the coming years, additional work is pl
 
 This project is an ongoing, multi-year collaboration with Transport Canada (TC),  Carleton University, and NAV CANADA, and was inspired by the work previously done by the Massachusetts Institute of Technology Lincoln Laboratory (MIT-LL).
 
-## Documents folder
+## Documents
+
+The `Documents/` folder contains the following reports:
 
 1. [LTR-FRL-2023-0055.pdf](Documents/LTR-FRL-2023-0055.pdf) details the process used for the statistical model creation, including an overview of the dataset and steps to generate Canadian statistical models. The report also includes the application and findings of the developed methodology for 12 airports across Canada.
 
 2. [LTR-FRL-2023-0053.pdf](Documents/LTR-FRL-2023-0053.pdf) provides the detailed description of the airspace classes and sensor equipment requirements in Canada as well as in the 12 selected airports.
 
-## Distributions Plot folder
+## Distributions Plot
 
-This folder contains matlab scripts to generate the statistical distributions for the selected Canadian airports as described in [LTR-FRL-2023-0055.pdf](Documents/LTR-FRL-2023-0055.pdf). To run the codes for statistical distributions, execute the `Plot_Distributions_Main.m` file.
+The `Distributions_Plot/` folder contains matlab scripts to generate the statistical distributions for the selected Canadian airports as described in LTR-FRL-2023-0055.pdf. To run the codes for statistical distributions, execute the `Plot_Distributions_Main.m` file.
 
-## Matlab Frequency Tables folder
+## Matlab Frequency Tables
 
-This folder contains frequency tables for initial and transition distributions of Bayesian networks for the Canada-wide statistical airspace model, which can be used for further encounter generation between an RPAS and traditional aviation.
+The `Matlab_Frequency_Tables/` folder contains frequency tables for initial and transition distributions of Bayesian networks for the Canada-wide statistical airspace model, which can be used for further encounter generation between an RPAS and traditional aviation.
 
 ## Support
 


### PR DESCRIPTION
Removing "folder" makes for better section titles, and then in the text the actual folder name (with underscores) is spelled out for perfect clarity.